### PR TITLE
Fix double initialization problem for twitter plugin

### DIFF
--- a/src/plugin/twitter.js
+++ b/src/plugin/twitter.js
@@ -25,6 +25,10 @@ class TwitterPlugin {
    * @return {CommandManager}
    */
   static init (channel) {
+    if (TwitterPlugin.initialized === true) {
+      return
+    }
+    TwitterPlugin.initialized = true;
     TwitterPlugin.channel = channel
     TwitterPlugin.twitterNames = new Set(config.twitter_users)
 


### PR DESCRIPTION
Ajout d'un state "initialized" pour empêcher le bot de ré-initializer une deuxième fois le plugin twitter (quand l'évènement "ready" de discord est déclenché une deuxième fois).